### PR TITLE
Fix/export formats

### DIFF
--- a/src/ExportEditor.ts
+++ b/src/ExportEditor.ts
@@ -325,16 +325,16 @@ export class ExportEditor<TResult> implements vscode.Disposable {
         }
       }
 
-      if (tokens[0] === 'F' && tokens.length === 5) {
+      if ((tokens[0] === 'F' || tokens[0] === 'R') && tokens.length === 5) {
         const [, type, name, ioFlag, unit] = tokens;
         const fileObj: FileDescriptor = {
           type: type,
           name: name,
           unit: unit,
         };
-        if (ioFlag === 'D') {
+        if (ioFlag === 'D' || ioFlag === 'DC') {
           formData.inputFiles.push(fileObj);
-        } else if (ioFlag === 'R') {
+        } else if (ioFlag === 'R' || ioFlag === 'RC') {
           formData.outputFiles.push(fileObj);
         }
       }

--- a/src/ExportEditor.ts
+++ b/src/ExportEditor.ts
@@ -19,9 +19,12 @@ interface FileDescriptor {
 interface Parameters {
   time_limit: string;
   memory_limit: string;
+  max_base: string;
   ncpus: string;
   mpi_nbcpu: string;
   mpi_nbnoeud: string;
+  testlist: string;
+  expected_diag: string;
 }
 
 interface FormData {
@@ -299,9 +302,12 @@ export class ExportEditor<TResult> implements vscode.Disposable {
       parameters: {
         time_limit: '',
         memory_limit: '',
+        max_base: '',
         ncpus: '',
         mpi_nbcpu: '',
         mpi_nbnoeud: '',
+        testlist: '',
+        expected_diag: '',
       },
       inputFiles: [],
       outputFiles: [],
@@ -318,8 +324,9 @@ export class ExportEditor<TResult> implements vscode.Disposable {
 
       const tokens = cleanLine.split(/\s+/);
 
-      if (tokens[0] === 'P' && tokens.length === 3) {
-        const [, key, value] = tokens;
+      if (tokens[0] === 'P' && tokens.length >= 3) {
+        const key = tokens[1];
+        const value = tokens.slice(2).join(' ');
         if (key in formData.parameters) {
           formData.parameters[key as keyof Parameters] = value;
         }

--- a/src/ExportFormatter.ts
+++ b/src/ExportFormatter.ts
@@ -45,7 +45,10 @@ const SECTION_HEADERS = {
   parameters: '# Simulation parameters',
   inputs: '# Input files',
   outputs: '# Output files',
+  unknown: '# Unknown lines',
 } as const;
+
+const VALID_IO_FLAGS = new Set(['D', 'DC', 'R', 'RC']);
 
 const STATIC_HEADER_LINES = [
   '# This file was generated using VS Code Aster - https://github.com/simvia-tech/vs-code-aster',
@@ -76,6 +79,7 @@ export function formatExportContent(text: string, filename?: string): string {
   const lines = text.split(/\r?\n/);
   const pEntries: Entry[] = [];
   const fEntries: Entry[] = [];
+  const unknownEntries: Entry[] = [];
   let pendingComments: string[] = [];
 
   for (const line of lines) {
@@ -91,10 +95,12 @@ export function formatExportContent(text: string, filename?: string): string {
     }
     const tokens = trimmed.split(/\s+/);
     const head = tokens[0];
-    if (head === 'P') {
+    const isValidFR =
+      (head === 'F' || head === 'R') && tokens.length === 5 && VALID_IO_FLAGS.has(tokens[3] ?? '');
+    if (head === 'P' && tokens.length >= 2) {
       pEntries.push({ comments: pendingComments, line: trimmed, type: '' });
       pendingComments = [];
-    } else if (head === 'F' || head === 'R') {
+    } else if (isValidFR) {
       const direction: 'D' | 'R' = tokens[3] === 'D' || tokens[3] === 'DC' ? 'D' : 'R';
       fEntries.push({
         comments: pendingComments,
@@ -103,6 +109,9 @@ export function formatExportContent(text: string, filename?: string): string {
         head: head as 'F' | 'R',
         direction,
       });
+      pendingComments = [];
+    } else {
+      unknownEntries.push({ comments: pendingComments, line: trimmed, type: '' });
       pendingComments = [];
     }
   }
@@ -127,6 +136,9 @@ export function formatExportContent(text: string, filename?: string): string {
   }
   if (rEntries.length > 0) {
     sections.push(`${SECTION_HEADERS.outputs}\n${renderSection(rEntries)}`);
+  }
+  if (unknownEntries.length > 0) {
+    sections.push(`${SECTION_HEADERS.unknown}\n${renderSection(unknownEntries)}`);
   }
   if (pendingComments.length > 0) {
     sections.push(pendingComments.join('\n'));

--- a/src/ExportFormatter.ts
+++ b/src/ExportFormatter.ts
@@ -4,6 +4,7 @@ interface Entry {
   comments: string[];
   line: string;
   type: string;
+  head?: 'F' | 'R';
   direction?: 'D' | 'R';
 }
 
@@ -29,6 +30,9 @@ function typeRank(type: string): number {
 }
 
 function byType(a: Entry, b: Entry): number {
+  if (a.head !== b.head) {
+    return a.head === 'F' ? -1 : 1;
+  }
   const pa = typeRank(a.type);
   const pb = typeRank(b.type);
   if (pa !== pb) {
@@ -90,12 +94,13 @@ export function formatExportContent(text: string, filename?: string): string {
     if (head === 'P') {
       pEntries.push({ comments: pendingComments, line: trimmed, type: '' });
       pendingComments = [];
-    } else if (head === 'F') {
-      const direction: 'D' | 'R' = tokens[3] === 'D' ? 'D' : 'R';
+    } else if (head === 'F' || head === 'R') {
+      const direction: 'D' | 'R' = tokens[3] === 'D' || tokens[3] === 'DC' ? 'D' : 'R';
       fEntries.push({
         comments: pendingComments,
         line: trimmed,
         type: tokens[1] ?? '',
+        head: head as 'F' | 'R',
         direction,
       });
       pendingComments = [];

--- a/syntaxes/export.tmLanguage.json
+++ b/syntaxes/export.tmLanguage.json
@@ -30,7 +30,7 @@
       ]
     },
     "file-line": {
-      "begin": "^\\s*(F)\\s+(\\S+)\\s+(\\S+)\\s+(?:(D)|(RC?))\\s+(\\S+)",
+      "begin": "^\\s*([FR])\\s+(\\S+)\\s+(\\S+)\\s+(?:(DC?)|(RC?))\\s+(\\S+)",
       "end": "$",
       "beginCaptures": {
         "1": { "name": "keyword.control.file.export" },

--- a/syntaxes/export.tmLanguage.json
+++ b/syntaxes/export.tmLanguage.json
@@ -5,7 +5,8 @@
   "patterns": [
     { "include": "#comment" },
     { "include": "#parameter-line" },
-    { "include": "#file-line" }
+    { "include": "#file-line" },
+    { "include": "#unknown-line" }
   ],
   "repository": {
     "comment": {
@@ -44,6 +45,10 @@
         { "include": "#comment" },
         { "include": "#extra-token" }
       ]
+    },
+    "unknown-line": {
+      "match": "^\\s*[^#\\s].*$",
+      "name": "invalid.illegal.unknown-line.export"
     }
   }
 }

--- a/webviews/export/src/components/App.svelte
+++ b/webviews/export/src/components/App.svelte
@@ -4,6 +4,7 @@
   import FieldRow from './FieldRow.svelte';
   import FileSection from './FileSection.svelte';
   import SubmitBar from './SubmitBar.svelte';
+  import Dropdown from './ui/Dropdown.svelte';
   import {
     DEFAULT_UNITS,
     getNextAvailableUnit,
@@ -26,17 +27,79 @@
     console.error('acquireVsCodeApi failed', e);
   }
 
+  const INTEGER_PARAMS = new Set([
+    'time_limit',
+    'memory_limit',
+    'max_base',
+    'ncpus',
+    'mpi_nbcpu',
+    'mpi_nbnoeud',
+  ]);
+  const OPTIONAL_PARAMS = new Set(['max_base', 'testlist', 'expected_diag']);
+
   let formData = $state<FormData>({
     name: 'simvia',
     parameters: {
       time_limit: '300',
       memory_limit: '1024',
+      max_base: '',
       ncpus: '1',
       mpi_nbcpu: '4',
       mpi_nbnoeud: '1',
+      testlist: '',
+      expected_diag: '',
     },
     inputFiles: [],
     outputFiles: [],
+  });
+
+  const TESTLIST_CONCURRENCY = ['sequential', 'parallel'] as const;
+  const TESTLIST_CATEGORY = ['verification', 'validation'] as const;
+  type Concurrency = (typeof TESTLIST_CONCURRENCY)[number] | '';
+  type Category = (typeof TESTLIST_CATEGORY)[number] | '';
+
+  function parseTestlist(raw: string): {
+    concurrency: Concurrency;
+    category: Category;
+    projects: string;
+  } {
+    let concurrency: Concurrency = '';
+    let category: Category = '';
+    const projects: string[] = [];
+    for (const token of raw.trim().split(/\s+/).filter(Boolean)) {
+      if ((TESTLIST_CONCURRENCY as readonly string[]).includes(token)) {
+        concurrency = token as Concurrency;
+      } else if ((TESTLIST_CATEGORY as readonly string[]).includes(token)) {
+        category = token as Category;
+      } else {
+        projects.push(token);
+      }
+    }
+    return { concurrency, category, projects: projects.join(' ') };
+  }
+
+  function serializeTestlist(
+    concurrency: Concurrency,
+    category: Category,
+    projects: string
+  ): string {
+    const parts: string[] = [];
+    if (concurrency) parts.push(concurrency);
+    if (category) parts.push(category);
+    const trimmedProjects = projects.trim();
+    if (category === 'validation' && trimmedProjects) {
+      parts.push(trimmedProjects);
+    }
+    return parts.join(' ');
+  }
+
+  let testlist = $state(parseTestlist(''));
+
+  $effect(() => {
+    const next = serializeTestlist(testlist.concurrency, testlist.category, testlist.projects);
+    if (next !== formData.parameters.testlist) {
+      formData.parameters.testlist = next;
+    }
   });
 
   let suggestionsFor = $state<Record<string, string[]>>({});
@@ -62,6 +125,12 @@
     }
 
     for (const [key, value] of Object.entries(formData.parameters)) {
+      if (!INTEGER_PARAMS.has(key)) {
+        continue;
+      }
+      if (OPTIONAL_PARAMS.has(key) && value.trim() === '') {
+        continue;
+      }
       if (!isInteger(value)) {
         errors[key] = `"${key}" must be a whole number.`;
       }
@@ -234,7 +303,11 @@
     const lines: string[] = [];
     lines.push(`${formData.name.trim()}.export`);
     for (const [key, value] of Object.entries(formData.parameters)) {
-      lines.push(`P ${key} ${value.trim()}`);
+      const trimmed = value.trim();
+      if (OPTIONAL_PARAMS.has(key) && trimmed === '') {
+        continue;
+      }
+      lines.push(`P ${key} ${trimmed}`);
     }
     for (const f of formData.inputFiles) {
       if (isEmptyFile(f)) {
@@ -274,6 +347,7 @@
     const saved = vscode?.getState() as { formData?: FormData } | undefined;
     if (saved?.formData) {
       Object.assign(formData, saved.formData);
+      testlist = parseTestlist(formData.parameters.testlist ?? '');
       loadedFromState = true;
     } else {
       formData.inputFiles.push({
@@ -375,6 +449,7 @@
           params[key] = v;
         }
       }
+      testlist = parseTestlist(formData.parameters.testlist);
     }
     if (
       (data.inputFiles && data.inputFiles.length > 0) ||
@@ -445,15 +520,96 @@
       bind:value={formData.parameters.mpi_nbcpu}
       error={errorFor['mpi_nbcpu']}
     />
-    <div class="col-start-2">
-      <FieldRow
-        id="mpi_nbnoeud"
-        label="MPI NBNOEUD"
-        kind="int"
-        bind:value={formData.parameters.mpi_nbnoeud}
-        error={errorFor['mpi_nbnoeud']}
-      />
+    <FieldRow
+      id="max_base"
+      label="Max Base (Mo)"
+      kind="int"
+      optional
+      placeholder="optional"
+      bind:value={formData.parameters.max_base}
+      error={errorFor['max_base']}
+    />
+    <FieldRow
+      id="mpi_nbnoeud"
+      label="MPI NBNOEUD"
+      kind="int"
+      bind:value={formData.parameters.mpi_nbnoeud}
+      error={errorFor['mpi_nbnoeud']}
+    />
+  </div>
+
+  <div class="mt-2 flex flex-col gap-2">
+    <div class="flex items-center gap-3">
+      <span class="w-40 shrink-0 text-sm font-semibold text-ui-text-secondary select-none">
+        Test list
+      </span>
+      <div class="flex-1 flex items-center gap-2 min-w-0">
+        <Dropdown
+          options={[
+            { value: '', label: '—' },
+            ...TESTLIST_CONCURRENCY.map((v) => ({ value: v, label: v })),
+          ]}
+          value={testlist.concurrency || null}
+          onSelect={(v) => (testlist.concurrency = v as Concurrency)}
+        >
+          <button
+            type="button"
+            class="flex items-center gap-1 bg-ui-input-bg border border-ui-input-border rounded-sm px-2 py-1 text-sm cursor-pointer focus:border-ui-focus focus:outline-none w-32 justify-between {testlist.concurrency
+              ? 'text-ui-input-fg'
+              : 'text-ui-text-muted italic'}"
+            aria-label="Test concurrency"
+          >
+            <span>{testlist.concurrency || 'concurrency'}</span>
+            <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor" aria-hidden="true">
+              <path d="M1 2.5 L4 5.5 L7 2.5 Z" />
+            </svg>
+          </button>
+        </Dropdown>
+        <Dropdown
+          options={[
+            { value: '', label: '—' },
+            ...TESTLIST_CATEGORY.map((v) => ({ value: v, label: v })),
+          ]}
+          value={testlist.category || null}
+          onSelect={(v) => (testlist.category = v as Category)}
+        >
+          <button
+            type="button"
+            class="flex items-center gap-1 bg-ui-input-bg border border-ui-input-border rounded-sm px-2 py-1 text-sm cursor-pointer focus:border-ui-focus focus:outline-none w-32 justify-between {testlist.category
+              ? 'text-ui-input-fg'
+              : 'text-ui-text-muted italic'}"
+            aria-label="Test category"
+          >
+            <span>{testlist.category || 'category'}</span>
+            <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor" aria-hidden="true">
+              <path d="M1 2.5 L4 5.5 L7 2.5 Z" />
+            </svg>
+          </button>
+        </Dropdown>
+        <input
+          id="testlist_projects"
+          type="text"
+          class="flex-1 min-w-0 bg-ui-input-bg border border-ui-input-border rounded-sm px-2 py-1 text-sm focus:border-ui-focus focus:outline-none {testlist.category ===
+          'validation'
+            ? 'text-ui-input-fg'
+            : 'text-ui-text-muted cursor-not-allowed'}"
+          placeholder={testlist.category === 'validation'
+            ? 'project(s), e.g. code seism'
+            : 'only for validation'}
+          disabled={testlist.category !== 'validation'}
+          bind:value={testlist.projects}
+        />
+      </div>
     </div>
+
+    <FieldRow
+      id="expected_diag"
+      label="Expected diag"
+      optional
+      placeholder="optional, e.g. NOOK_TEST_RESU"
+      bind:value={formData.parameters.expected_diag}
+      error={errorFor['expected_diag']}
+    />
   </div>
 
   <FileSection

--- a/webviews/export/src/components/App.svelte
+++ b/webviews/export/src/components/App.svelte
@@ -58,28 +58,36 @@
     const errors: Record<string, string> = {};
 
     if (formData.name.trim() === '') {
-      errors['envName'] = 'File name is required.';
+      errors['envName'] = 'The export file name is required.';
     }
 
     for (const [key, value] of Object.entries(formData.parameters)) {
       if (!isInteger(value)) {
-        errors[key] = `"${key}" must be an integer.`;
+        errors[key] = `"${key}" must be a whole number.`;
       }
     }
 
     const checkFiles = (files: FileDescriptor[], label: 'Input' | 'Output') => {
-      files.forEach((f) => {
+      files.forEach((f, idx) => {
         if (isEmptyFile(f)) {
           return;
         }
-        if (!f.name.trim()) {
-          errors[`name-${f.id}`] = `${label} file: missing file name.`;
-        }
+        const prefix = `${label} file #${idx + 1}`;
+        const trimmedName = f.name.trim();
+        const dotIdx = trimmedName.lastIndexOf('.');
+        const base = dotIdx >= 0 ? trimmedName.slice(0, dotIdx) : trimmedName;
+        const ext = dotIdx >= 0 ? trimmedName.slice(dotIdx + 1) : '';
         if (!f.type.trim()) {
-          errors[`type-${f.id}`] = `${label} file: missing type.`;
+          errors[`type-${f.id}`] = `${prefix}: file type is required.`;
+        }
+        if (!base) {
+          errors[`name-${f.id}`] = `${prefix}: file name is required.`;
+        }
+        if (!ext) {
+          errors[`ext-${f.id}`] = `${prefix}: file extension is required.`;
         }
         if (!isInteger(f.unit)) {
-          errors[`unit-${f.id}`] = 'Unit must be an integer.';
+          errors[`unit-${f.id}`] = `${prefix}: unit must be a whole number.`;
         }
       });
     };
@@ -98,8 +106,22 @@
     return out;
   });
 
+  let allErrors = $derived<{ targetId?: string; message: string }[]>([
+    ...Object.entries(errorFor).map(([targetId, message]) => ({ targetId, message })),
+    ...formErrors.map((message) => ({ message })),
+  ]);
+
+  function focusTarget(id: string) {
+    const el = document.getElementById(id);
+    if (!el) {
+      return;
+    }
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    (el as HTMLElement).focus({ preventScroll: true });
+  }
+
   let warnings = $derived.by(() => {
-    const out: string[] = [];
+    const out: { targetId?: string; message: string }[] = [];
 
     if (
       mode === 'edit' &&
@@ -107,9 +129,10 @@
       formData.name.trim() &&
       formData.name.trim() !== originalName
     ) {
-      out.push(
-        `Saving will rename ${originalName}.export to ${formData.name.trim()}.export. The original file will be deleted.`
-      );
+      out.push({
+        targetId: 'envName',
+        message: `Saving will rename ${originalName}.export to ${formData.name.trim()}.export. The original file will be deleted.`,
+      });
     }
 
     const meshTypes = new Set(['mmed', 'mail', 'msh']);
@@ -117,15 +140,21 @@
       (f) => !isEmptyFile(f) && meshTypes.has(f.type)
     );
     if (!hasMesh) {
-      out.push('No mesh file is set (mmed, mail, or msh).');
+      out.push({
+        targetId: 'add-input',
+        message: 'No mesh file is set (mmed, mail, or msh).',
+      });
     }
 
     const hasRmed = formData.outputFiles.some((f) => !isEmptyFile(f) && f.type === 'rmed');
     if (!hasRmed) {
-      out.push('No rmed output file is set.');
+      out.push({
+        targetId: 'add-output',
+        message: 'No rmed output file is set.',
+      });
     }
 
-    const byUnit = new Map<string, string[]>();
+    const byUnit = new Map<string, { names: string[]; firstId: string }>();
     for (const f of [...formData.inputFiles, ...formData.outputFiles]) {
       if (isEmptyFile(f)) {
         continue;
@@ -138,13 +167,19 @@
         continue;
       }
       const label = f.name.trim() || `(unnamed ${f.type || 'file'})`;
-      const existing = byUnit.get(unitStr) ?? [];
-      existing.push(label);
-      byUnit.set(unitStr, existing);
+      const existing = byUnit.get(unitStr);
+      if (existing) {
+        existing.names.push(label);
+      } else {
+        byUnit.set(unitStr, { names: [label], firstId: f.id });
+      }
     }
-    for (const [unit, names] of byUnit) {
+    for (const [unit, { names, firstId }] of byUnit) {
       if (names.length > 1) {
-        out.push(`Multiple files share unit ${unit}: ${names.join(', ')}`);
+        out.push({
+          targetId: `unit-${firstId}`,
+          message: `Multiple files share unit ${unit}: ${names.join(', ')}`,
+        });
       }
     }
     return out;
@@ -205,13 +240,17 @@
       if (isEmptyFile(f)) {
         continue;
       }
-      lines.push(`F ${f.type} ${f.name.trim()} D ${f.unit.trim()}`);
+      const head = f.type === 'base' ? 'R' : 'F';
+      const status = f.type === 'base' ? 'DC' : 'D';
+      lines.push(`${head} ${f.type} ${f.name.trim()} ${status} ${f.unit.trim()}`);
     }
     for (const f of formData.outputFiles) {
       if (isEmptyFile(f)) {
         continue;
       }
-      lines.push(`F ${f.type} ${f.name.trim()} R ${f.unit.trim()}`);
+      const head = f.type === 'base' ? 'R' : 'F';
+      const status = f.type === 'base' ? 'RC' : 'R';
+      lines.push(`${head} ${f.type} ${f.name.trim()} ${status} ${f.unit.trim()}`);
     }
     vscode?.postMessage({ command: 'result', value: lines.join('\n') });
   }
@@ -445,34 +484,45 @@
     onRemove={removeFile}
   />
 
-  {#if formErrors.length > 0}
+  {#if allErrors.length > 0}
     <div
       id="panel-errors"
-      class="mt-6 p-4 rounded border text-sm scroll-mt-8 scroll-mb-20"
+      class="panel-errors mt-6 p-4 rounded border text-sm scroll-mt-8 scroll-mb-20"
       style="border-color: var(--vscode-inputValidation-errorBorder, #d45858); background: color-mix(in srgb, var(--vscode-inputValidation-errorBorder, #d45858) 12%, transparent); color: var(--vscode-inputValidation-errorBorder, #d45858)"
       role="alert"
     >
-      <div class="font-semibold mb-3">Cannot save</div>
-      <ul class="flex flex-col gap-2.5">
-        {#each formErrors as e}
-          <li class="flex items-start gap-2">
-            <svg
-              class="shrink-0 mt-0.5"
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              aria-hidden="true"
+      <div class="font-semibold mb-3">
+        {allErrors.length === 1 ? 'Error' : 'Errors'}
+      </div>
+      <ul class="flex flex-col gap-0.5">
+        {#each allErrors as e}
+          <li>
+            <button
+              type="button"
+              class="panel-row w-full text-left flex items-start gap-2 py-1 px-2 -mx-1 rounded {e.targetId
+                ? 'cursor-pointer'
+                : 'cursor-default'}"
+              disabled={!e.targetId}
+              onclick={() => e.targetId && focusTarget(e.targetId)}
             >
-              <circle cx="12" cy="12" r="10" />
-              <line x1="12" y1="8" x2="12" y2="12" />
-              <line x1="12" y1="16" x2="12.01" y2="16" />
-            </svg>
-            <span>{e}</span>
+              <svg
+                class="shrink-0 mt-0.5"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+              <span>{e.message}</span>
+            </button>
           </li>
         {/each}
       </ul>
@@ -482,31 +532,44 @@
   {#if warnings.length > 0}
     <div
       id="panel-warnings"
-      class="mt-6 p-4 rounded border text-sm scroll-mt-8 scroll-mb-20"
+      class="panel-warnings mt-6 p-4 rounded border text-sm scroll-mt-8 scroll-mb-20"
       style="border-color: var(--vscode-editorWarning-foreground, #cca700); background: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 10%, transparent); color: var(--vscode-editorWarning-foreground, #cca700)"
       role="alert"
     >
-      <div class="font-semibold mb-3">Warning</div>
-      <ul class="flex flex-col gap-2.5">
+      <div class="font-semibold mb-3">
+        {warnings.length === 1 ? 'Warning' : 'Warnings'}
+      </div>
+      <ul class="flex flex-col gap-0.5">
         {#each warnings as w}
-          <li class="flex items-start gap-2">
-            <svg
-              class="shrink-0 mt-0.5"
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              aria-hidden="true"
+          <li>
+            <button
+              type="button"
+              class="panel-row w-full text-left flex items-start gap-2 py-1 px-2 -mx-1 rounded {w.targetId
+                ? 'cursor-pointer'
+                : 'cursor-default'}"
+              disabled={!w.targetId}
+              onclick={() => w.targetId && focusTarget(w.targetId)}
             >
-              <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
-              <path d="M12 9v4" />
-              <path d="M12 17h.01" />
-            </svg>
-            <span>{w}</span>
+              <svg
+                class="shrink-0 mt-0.5"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path
+                  d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"
+                />
+                <path d="M12 9v4" />
+                <path d="M12 17h.01" />
+              </svg>
+              <span>{w.message}</span>
+            </button>
           </li>
         {/each}
       </ul>
@@ -526,3 +589,20 @@
     onScrollToWarnings={() => scrollTo('panel-warnings')}
   />
 </main>
+
+<style>
+  .panel-errors .panel-row:not(:disabled):hover {
+    background: color-mix(
+      in srgb,
+      var(--vscode-inputValidation-errorBorder, #d45858) 18%,
+      transparent
+    );
+  }
+  .panel-warnings .panel-row:not(:disabled):hover {
+    background: color-mix(
+      in srgb,
+      var(--vscode-editorWarning-foreground, #cca700) 18%,
+      transparent
+    );
+  }
+</style>

--- a/webviews/export/src/components/FieldRow.svelte
+++ b/webviews/export/src/components/FieldRow.svelte
@@ -10,6 +10,7 @@
     error?: string;
     accent?: boolean;
     suffix?: string;
+    optional?: boolean;
   }
 
   let {
@@ -21,9 +22,12 @@
     error = '',
     accent = false,
     suffix = '',
+    optional = false,
   }: Props = $props();
 
-  let invalid = $derived(!!error || (kind === 'int' && !isInteger(value)));
+  let invalid = $derived(
+    !!error || (kind === 'int' && !(optional && value.trim() === '') && !isInteger(value))
+  );
 
   function handleKeydown(e: KeyboardEvent) {
     if (kind !== 'int') {

--- a/webviews/export/src/components/FileRow.svelte
+++ b/webviews/export/src/components/FileRow.svelte
@@ -35,8 +35,10 @@
   }: Props = $props();
 
   let nameError = $derived(errorFor[`name-${file.id}`] ?? '');
+  let extError = $derived(errorFor[`ext-${file.id}`] ?? '');
   let unitError = $derived(errorFor[`unit-${file.id}`] ?? '');
   let typeError = $derived(errorFor[`type-${file.id}`] ?? '');
+  let rowErrors = $derived([typeError, nameError, extError, unitError].filter((m) => m !== ''));
 
   let typeOptions = $derived(
     (kind === 'input' ? INPUT_TYPES : OUTPUT_TYPES).map((t) => ({ value: t, label: t }))
@@ -44,9 +46,31 @@
 
   let unitLocked = $derived(isFixedZeroType(file.type));
 
+  function splitName(name: string): { base: string; ext: string } {
+    const idx = name.lastIndexOf('.');
+    if (idx < 0) {
+      return { base: name, ext: '' };
+    }
+    return { base: name.slice(0, idx), ext: name.slice(idx + 1) };
+  }
+
+  let baseName = $state(splitName(file.name).base);
+  let extension = $state(splitName(file.name).ext);
+
+  $effect(() => {
+    const composed = extension ? `${baseName}.${extension}` : baseName;
+    if (composed !== file.name) {
+      file.name = composed;
+    }
+  });
+
   function handleTypeChange(newType: string) {
     if (file.type === newType) {
       return;
+    }
+    const previousType = file.type;
+    if (extension === '' || extension === previousType) {
+      extension = newType;
     }
     file.type = newType;
     if (isFixedZeroType(newType)) {
@@ -72,7 +96,15 @@
   }
 
   function handleNameQuery(value: string) {
-    file.name = value;
+    // Suggestions are full filenames ("simvia.comm"); if a dot is present,
+    // split it so the two fields stay coherent.
+    const { base, ext } = splitName(value);
+    if (ext) {
+      baseName = base;
+      extension = ext;
+    } else {
+      baseName = value;
+    }
     onAutocompleteQuery(file.id, value, file.type);
   }
 </script>
@@ -113,12 +145,24 @@
 
     <AutocompleteInput
       id={`name-${file.id}`}
-      bind:value={file.name}
+      bind:value={baseName}
       placeholder="File name"
       invalid={!!nameError}
       suggestions={suggestionsFor[file.id] ?? []}
       onQuery={handleNameQuery}
       onFocusChange={(focused) => onAutocompleteFocus(focused ? file.id : null)}
+    />
+
+    <span class="text-ui-text-muted select-none">.</span>
+
+    <input
+      id={`ext-${file.id}`}
+      aria-label="File extension"
+      type="text"
+      class="w-20 shrink-0 bg-ui-input-bg border border-ui-input-border rounded-sm px-2 py-1 text-sm text-ui-input-fg focus:border-ui-focus focus:outline-none"
+      class:input-warning={!!extError}
+      placeholder="ext"
+      bind:value={extension}
     />
 
     <input
@@ -156,9 +200,14 @@
     </button>
   </div>
 
-  {#if nameError || unitError || typeError}
-    <p class="px-7 text-xs" style="color: var(--vscode-inputValidation-errorBorder, #d45858)">
-      {nameError || typeError || unitError}
-    </p>
+  {#if rowErrors.length > 0}
+    <ul
+      class="px-7 text-xs flex flex-col gap-0.5"
+      style="color: var(--vscode-inputValidation-errorBorder, #d45858)"
+    >
+      {#each rowErrors as message}
+        <li>{message}</li>
+      {/each}
+    </ul>
   {/if}
 </div>

--- a/webviews/export/src/components/FileSection.svelte
+++ b/webviews/export/src/components/FileSection.svelte
@@ -80,6 +80,7 @@
   </div>
 
   <button
+    id={`add-${kind}`}
     type="button"
     class="w-full mt-3 flex items-center justify-center gap-1.5 py-1.5 rounded border border-dashed border-ui-border text-xs font-medium text-ui-text-secondary hover:text-ui-fg hover:bg-ui-elem hover:border-ui-text-muted cursor-pointer transition-colors"
     aria-label={`Add ${kind} file`}

--- a/webviews/export/src/components/SubmitBar.svelte
+++ b/webviews/export/src/components/SubmitBar.svelte
@@ -30,7 +30,7 @@
     {#if errorCount > 0}
       <button
         type="button"
-        class="flex items-center gap-1.5 font-medium cursor-pointer hover:underline focus:outline-none focus:underline rounded"
+        class="pill pill-error flex items-center gap-1.5 font-medium cursor-pointer focus:outline-none rounded px-2 py-1 -mx-2"
         style="color: var(--vscode-inputValidation-errorBorder, #d45858)"
         aria-label={`Jump to ${errorCount} error${errorCount === 1 ? '' : 's'}`}
         onclick={onScrollToErrors}
@@ -57,7 +57,7 @@
     {#if warningCount > 0}
       <button
         type="button"
-        class="flex items-center gap-1.5 font-medium cursor-pointer hover:underline focus:outline-none focus:underline rounded"
+        class="pill pill-warning flex items-center gap-1.5 font-medium cursor-pointer focus:outline-none rounded px-2 py-1 -mx-2"
         style="color: var(--vscode-editorWarning-foreground, #cca700)"
         aria-label={`Jump to ${warningCount} warning${warningCount === 1 ? '' : 's'}`}
         onclick={onScrollToWarnings}
@@ -101,3 +101,22 @@
     </button>
   </div>
 </div>
+
+<style>
+  .pill-error:hover,
+  .pill-error:focus-visible {
+    background: color-mix(
+      in srgb,
+      var(--vscode-inputValidation-errorBorder, #d45858) 16%,
+      transparent
+    );
+  }
+  .pill-warning:hover,
+  .pill-warning:focus-visible {
+    background: color-mix(
+      in srgb,
+      var(--vscode-editorWarning-foreground, #cca700) 16%,
+      transparent
+    );
+  }
+</style>

--- a/webviews/export/src/lib/types.ts
+++ b/webviews/export/src/lib/types.ts
@@ -70,9 +70,12 @@ export interface FileDescriptor {
 export interface Parameters {
   time_limit: string;
   memory_limit: string;
+  max_base: string;
   ncpus: string;
   mpi_nbcpu: string;
   mpi_nbnoeud: string;
+  testlist: string;
+  expected_diag: string;
 }
 
 export interface FormData {

--- a/webviews/export/src/lib/types.ts
+++ b/webviews/export/src/lib/types.ts
@@ -90,43 +90,64 @@ export function newRowId(prefix = 'row'): string {
 
 /**
  * Returns the next integer unit for a file of the given `type`.
- * Scoped to same-type rows only (so `comm` numbering does not jump over
- * unrelated `med` units). `excludeId` skips the file being re-assigned,
- * so re-picking the same type for an existing row is idempotent.
+ * `excludeId` skips the file being re-assigned, so re-picking the same
+ * type for an existing row is idempotent.
  *
- * Rule: start at the type's default. If any same-type unit is >= default,
- * return `max(usedUnits >= default) + 1`; otherwise return the default.
+ * Rules:
+ * - Fixed-zero types (e.g. `nom`) always return `0`.
+ * - If another file of the same type exists, continue that type's own
+ *   sequence: `max(usedUnits >= default) + 1`, or the default if none.
+ * - Otherwise (type not yet present), return the highest unit across all
+ *   files rounded up to the next multiple of 10 (e.g. 30 → 40, 31 → 40).
+ *   Falls back to the type's default when no file has a positive unit.
  */
 export function getNextAvailableUnit(
   type: string,
   files: FileDescriptor[],
   excludeId?: string
 ): string {
+  if (isFixedZeroType(type)) {
+    return '0';
+  }
   const defaultUnit = DEFAULT_UNITS[type as AllowedType];
   if (defaultUnit === undefined) {
     return '0';
   }
   const start = Number(defaultUnit);
-  if (!Number.isFinite(start) || start === 0) {
-    return '0';
-  }
-  const usedAtOrAbove: number[] = [];
-  for (const f of files) {
-    if (f.id === excludeId) {
-      continue;
-    }
+  const others = files.filter((f) => f.id !== excludeId);
+
+  const sameTypeAtOrAbove: number[] = [];
+  let sameTypePresent = false;
+  for (const f of others) {
     if (f.type !== type) {
       continue;
     }
+    sameTypePresent = true;
     const n = Number(f.unit);
-    if (Number.isInteger(n) && n >= start) {
-      usedAtOrAbove.push(n);
+    if (Number.isInteger(n) && Number.isFinite(start) && start > 0 && n >= start) {
+      sameTypeAtOrAbove.push(n);
     }
   }
-  if (usedAtOrAbove.length === 0) {
+
+  if (sameTypePresent) {
+    if (sameTypeAtOrAbove.length > 0) {
+      return String(Math.max(...sameTypeAtOrAbove) + 1);
+    }
+    if (Number.isFinite(start) && start > 0) {
+      return String(start);
+    }
+  }
+
+  const allPositive = others.map((f) => Number(f.unit)).filter((n) => Number.isInteger(n) && n > 0);
+  if (allPositive.length > 0) {
+    const max = Math.max(...allPositive);
+    return String((Math.floor(max / 10) + 1) * 10);
+  }
+
+  if (Number.isFinite(start) && start > 0) {
     return String(start);
   }
-  return String(Math.max(...usedAtOrAbove) + 1);
+  return '0';
 }
 
 export function isInteger(value: string): boolean {


### PR DESCRIPTION
Round of fixes and UX improvements for the `.export` editor: wider grammar coverage (base directories, unknown lines), three previously-dropped parameters, split basename/extension inputs, smarter defaults, and a reworked error/warning panel.

### Added
- **Base directory support** — `R extension name D/DC/RC unit` lines are now parsed, formatted, and syntax-highlighted alongside standard `F` files, so `.export` files using the `base` type round-trip correctly.
- **`max_base`, `testlist`, `expected_diag` parameters** — the three remaining documented execution parameters are now first-class form fields. Multi-token `P` values (e.g. `P testlist parallel validation code`) are preserved end-to-end. `testlist` uses a structured selector (sequential/parallel + verification/validation + projects input, enabled only when validation is chosen). Optional parameters are omitted from the output when left blank.
- **Separate file name and extension inputs** — each file row now shows a basename field and an extension field joined by a visible `.`, so the extension can be prefilled from the chosen type while the basename stays easy to edit.
- **Smarter default unit** — when adding a file whose type isn't already present, the new unit is derived from the highest existing unit rounded up to the next multiple of 10 (e.g. 30 → 40) instead of defaulting to 0.
- **"Unknown lines" preservation** — lines the formatter can't interpret are now collected under a trailing `# Unknown lines` section instead of being dropped, and are highlighted as invalid in the syntax grammar so they stand out.

### Changed
- **Error and warning panels** — merged into a single list showing every individual problem (per-field errors, missing-name, missing-extension, missing-type, bad unit, and form-level issues) with pluralized "Error(s)" / "Warning(s)" headers. Each row is clickable: errors jump to the offending input, warnings jump to a sensible anchor (rename → filename, missing mesh/rmed → the matching "Add" button, unit clash → the first offending file's unit input).
- **Submit bar** — the error/warning pills got a subtle tinted hover/focus background to feel clickable.

### Fixed
- Entering text into the file name or extension inputs no longer silently reverts due to a state-sync feedback loop.
- Webview form fields no longer flag optional integer parameters as invalid when left empty.